### PR TITLE
Fixes #3 - Add support for servers

### DIFF
--- a/templates/settings.xml.j2
+++ b/templates/settings.xml.j2
@@ -9,4 +9,20 @@
 {% endif %}
     </pluginGroups>
 
+    <servers>
+{% if maven_settings.maven_servers is defined %}
+{% for item in maven_settings.maven_servers %}
+        <server>
+            <id>{{ item.id }}</id>
+{% if item.username is defined %}
+            <username>{{ item.username }}</username>
+{% endif %}
+{% if item.password is defined %}
+            <password>{{ item.password }}</password>
+{% endif %}
+        </server>
+{% endfor %}
+{% endif %}
+    </servers>
+
 </settings>


### PR DESCRIPTION
Added support for the servers element. This is dependent on the maven_settings.maven_servers variable.
The template is conditional so absense of the variable will omit the relevant sections.

---Jaco
